### PR TITLE
Design: TagButtonGroup.vue 텍스트 색상 변경

### DIFF
--- a/Frontend/tarzan/src/components/common/TagButtonGroup.vue
+++ b/Frontend/tarzan/src/components/common/TagButtonGroup.vue
@@ -71,6 +71,7 @@ const toggleSelection = (value) => {
   font-weight: 600;
   white-space: nowrap;
   padding: 13px 14px;
+  @include custom-text;
   cursor: pointer;
   &:focus {
     outline: none;


### PR DESCRIPTION
**iOS 사파리 화면에서 TagButtonGroup 컴포넌트의 텍스트 색상이 버튼의 기본 색상인 파랑색으로 나타는 문제 발생**
- TagButtonGroup 컴포넌트의 텍스트 색상을 믹스인의 custom-text 기본으로 변경