### PR TITLE
feat: TopBar에서 커스텀 이동이 가능하도록 뒤로가기 로직 개선

### DIFF
--- a/Frontend/tarzan/src/components/common/TopBarBack.vue
+++ b/Frontend/tarzan/src/components/common/TopBarBack.vue
@@ -4,28 +4,32 @@
       id="back-button"
       src="@/assets/icons/Filter/back-icon.png"
       alt="back-button"
-      @click="goBack"
+      @click="onBackClick"
     />
     <div class="title">{{ title }}</div>
     <slot></slot>
   </div>
 </template>
 
-<script>
-export default {
-  name: "Topbar",
-  props: {
-    title: {
-      type: String,
-      required: true,
-    },
+<script setup>
+import { defineProps, defineEmits } from 'vue';
+
+const emit = defineEmits(['back']);
+
+const props = defineProps({
+  title: {
+    type: String,
+    required: true,
   },
-  methods: {
-    goBack() {
-      this.$router.go(-1);
-    },
-  },
-};
+});
+
+function onBackClick() {
+  emit('back');
+}
+
+// function goBack() {
+//   router.go(-1);
+// }
 </script>
 
 <style lang="scss" scoped>

--- a/Frontend/tarzan/src/components/fraud/CheckRealEstateBroker.vue
+++ b/Frontend/tarzan/src/components/fraud/CheckRealEstateBroker.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="sub-container non-input-sub-container">
-    <TopBarBack title="공인중개사 확인" />
+    <TopBarBack title="공인중개사 확인" @back="goSomewhere" />
     <div class="center-container">
       <form class="input-form">
         <!-- 컴포넌트 화 하기 -->
@@ -76,11 +76,13 @@
 
 <script setup lang="ts">
 import { ref, Ref } from "vue";
-
+import { useRouter } from 'vue-router';
 import { Option } from "@/data/options";
 // import DropDown from "@/components/common/DropDown.vue";
 import CustomSelectBox from "@/components/common/CustomSelectBox.vue";
 import TopBarBack from "../common/TopBarBack.vue";
+
+const router = useRouter();
 
 const seoulDistrictOptions: Option[] = [
   { idx: 0, name: "서울시 종로구", value: "JONGNO" },
@@ -118,6 +120,10 @@ const searchOption: Option[] = [
 ];
 
 const resultCnt: Ref<number> = ref(0);
+
+function goSomewhere() {
+  router.push({ name: 'Home' }); // 또는 router.go(-1) 도 가능
+}
 </script>
 
 <style lang="scss" scoped>

--- a/Frontend/tarzan/src/pages/Community.vue
+++ b/Frontend/tarzan/src/pages/Community.vue
@@ -17,10 +17,10 @@
 
       <div class="tag-button-container">
 
-        <TagButtonGroup v-model:selectedButton="selectedButton" :buttons="tagOptions" :multiple="false">
-          <template v-slot:default="{ button }">
-            <span>{{ button.label }}</span>
-          </template>
+        <TagButtonGroup 
+          v-model:selectedButton="selectedButton" 
+          :buttons="tagOptions" 
+          :multiple="false">
         </TagButtonGroup>
       </div>
 
@@ -188,7 +188,9 @@ const goToPostCreate = () => {
   }
 
   .tag-button-container {
-    margin: 8px;
+    width: 100%;
+    padding: 8px;
+    background-color: yellowgreen;
   }
 
   .result-bar-container {


### PR DESCRIPTION
**TopBar.vue의 goBack 함수를 onBackClick 이벤트 방식으로 변경**

### 변경 이유
- 기존에는 back 버튼 클릭 시 무조건 이전 페이지로만 이동했음
- 상황에 따라 특정 경로(예: 홈, 마이페이지 등)로 이동해야 하는 경우가 있어 개선 필요

### 변경 내용
- goBack() → onBackClick()으로 함수명 변경
- TopBar 내부에서 직접 라우터 제어하지 않고, 상위 컴포넌트로 이벤트(`@back`) 전달
- 상위 컴포넌트에서 원하는 라우터 경로로 이동 가능하도록 구조 변경

### 기대 효과
- TopBar를 여러 페이지에서 재사용할 때 유연하게 라우팅 처리 가능
- 컴포넌트 역할 분리(TopBar는 UI, 라우팅은 상위에서 결정)
