### PR TITLE
feat: TagButtonGroup에 activeClass prop 추가 및 선택 상태 로직 개선

### DIFF
--- a/Frontend/tarzan/src/components/common/TagButtonGroup.vue
+++ b/Frontend/tarzan/src/components/common/TagButtonGroup.vue
@@ -15,16 +15,11 @@
       v-for="button in buttons"
       :key="button.value"
       class="tag-button"
-      :class="{
-        active: multiple
-          ? selectedButtons.includes(button.value)
-          : selectedButton === button.value,
-      }"
+      :class="{ [activeClass]: isSelected(button.value) }"
       role="button"
       tabindex="0"
       @click="toggleSelection(button.value)"
-      @keydown.enter="toggleSelection(button.value)"
-      @keydown.space.prevent="toggleSelection(button.value)">
+    >
       <slot :button="button">{{ button.label }}</slot>
     </div>
   </div>
@@ -34,24 +29,31 @@
 import { defineProps, defineEmits } from "vue";
 
 const props = defineProps({
-  selectedButton: String, // 단일 선택용 prop
-  selectedButtons: Array, // 다중 선택용 prop
+  selectedButton: String,
+  selectedButtons: Array,
   buttons: Array,
-  multiple: Boolean, // 단일 선택 vs 다중 선택 모드
+  multiple: Boolean,
+  activeClass: {
+    type: String,
+    default: "active", // 기본값은 기존과 동일하게 유지
+  },
 });
 
 const emit = defineEmits(["update:selectedButton", "update:selectedButtons"]);
 
-// 선택된 버튼 토글 (단일/다중 선택 모드에 따라 다르게 동작)
+const isSelected = (value) => {
+  return props.multiple
+    ? props.selectedButtons.includes(value)
+    : props.selectedButton === value;
+};
+
 const toggleSelection = (value) => {
   if (props.multiple) {
-    // 다중 선택 모드
-    const updatedSelection = props.selectedButtons.includes(value)
-      ? props.selectedButtons.filter((v) => v !== value) // 선택 해제
-      : [...props.selectedButtons, value]; // 선택 추가
-    emit("update:selectedButtons", updatedSelection);
+    const updated = props.selectedButtons.includes(value)
+      ? props.selectedButtons.filter((v) => v !== value)
+      : [...props.selectedButtons, value];
+    emit("update:selectedButtons", updated);
   } else {
-    // 단일 선택 모드
     emit("update:selectedButton", value);
   }
 };
@@ -78,7 +80,7 @@ const toggleSelection = (value) => {
   }
 }
 
-.tag-button.active {
+.active {
   background-color: $primary-color-light;
   border: 1.2px solid $primary-color-default;
   color: $primary-color-default;


### PR DESCRIPTION
## 변경 내용
- TagButtonGroup 컴포넌트에 `activeClass` prop 추가
- 선택된 버튼에 외부에서 클래스를 넘겨 스타일을 커스터마이징할 수 있도록 개선
- 선택 여부 로직을 `isSelected()` 함수로 분리해 가독성 향상

## 변경 이유
- 화면마다 버튼 선택 스타일을 다르게 보여줄 필요가 있었고,
- 기존에는 내부 스타일 고정이라 확장성이 떨어졌음
