### PR TITLE
refactor: 검색바(SearchBar) 컴포넌트를 분리하여 Search.vue로 리팩토링

### DIFF
--- a/Frontend/tarzan/src/components/common/SearchBar.vue
+++ b/Frontend/tarzan/src/components/common/SearchBar.vue
@@ -1,13 +1,8 @@
 <template>
-  <div class="searchbar">
+  <div class="searchbar" @click="goToSearch">
     <div class="input-icon-wrap">
-        <input
-          v-model="searchQuery" 
-          type="text"
-          placeholder="찾고 싶은 글 제목을 입력해주세요."
-          readonly
-          @focus="goToSearch"
-        />
+      <img :src="searchIconImg" alt="search icon" class="icon-search" />
+      <p>찾고 싶은 주소를 입력해주세요.</p>
     </div>
   </div>
 </template>
@@ -15,49 +10,57 @@
 <script setup>
 import { ref, defineEmits } from 'vue';
 import router from '@/router';
+import searchIconImg from "@/assets/icons/Magnifier.png";
 
-const searchQuery = ref('');
-const emit = defineEmits();
+const props = defineProps({
+  // 이동할 라우트 이름
+  routeName: {
+    type: String,
+    default: 'Home',
+  },
+});
 
-// 게시물 검색 페이지로 이동
+// 검색 페이지로 이동
 const goToSearch = () => {
-  router.push({ name: 'PostSearch' }) // 라우터 이름은 아래에 정의
+  console.log('라우트로 이동 시도:', props.routeName);
+  try {
+    router.push({
+      name: props.routeName,
+    });
+    console.log('라우트로 이동', props.routeName);
+  } catch (error) {
+    console.error('라우트 이동 오류:', error);
+  }
 }
 </script>
 
 <style lang="scss" scoped>
-  .searchbar {
-    display: flex;
-    padding-top: $margin-small;
-    padding-bottom: $margin-default;
+.searchbar {
+  @include custom-margin-x;
+  @include custom-padding-y;
+  display: flex;
+  cursor: pointer;
+  .input-icon-wrap {
     @include custom-padding-x;
-    box-sizing: border-box;
-    cursor: pointer;
-  }
-
-  .searchbar .input-icon-wrap {
     display: flex;
+    gap: $padding-default;
     align-items: center;
     width: 100%;
     height: 48px;
     border-radius: 13px;
-    background-color: $input-color;
+    background-color: white;
     padding-right: $padding-default;
-  }
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    cursor: pointer;
 
-  .searchbar .input-icon-wrap .icon-search {
-    width: 16px;
-    height: 16px;
-    @include custom-margin-x;
-    color: $input-placeholder-color;
-  }
+    .icon-search {
+      @include custom-icon-style;
+      color: $input-placeholder-color;
+    }
 
-  .searchbar .input-icon-wrap input {
-    width: 100%;
-    appearance: none;
-    border: none;
-    outline: none;
-    background: transparent;
-    @include custom-text;
+    p {
+      @include custom-text($font-size: 14px, $font-color: $text-color-light);
+    }
   }
+};
 </style>

--- a/Frontend/tarzan/src/components/common/TagButtonGroup.vue
+++ b/Frontend/tarzan/src/components/common/TagButtonGroup.vue
@@ -48,12 +48,6 @@ const toggleSelection = (value) => {
 </script>
 
 <style scoped lang="scss">
-// .tag-button-container {
-//   display: flex;
-//   flex-wrap: nowrap;
-//   gap: 5px;
-
-// }
 .tag-button-container {
   display: flex;
   flex-wrap: nowrap;
@@ -85,6 +79,9 @@ const toggleSelection = (value) => {
   }
 }
 
+// 선택된 버튼의 스타일
+// 기존의 active 클래스를 사용하여 스타일을 적용합니다.
+// 필요에 따라 기존 스타일을 수정하거나 추가할 수 있습니다.
 .active {
   background-color: $primary-color-light;
   border: 1.2px solid $primary-color-default;

--- a/Frontend/tarzan/src/pages/Community.vue
+++ b/Frontend/tarzan/src/pages/Community.vue
@@ -6,7 +6,9 @@
     /> 
     
     <div class="center-container">
-      <SearchBar />
+      <SearchBar
+        routeName="PostSearch"    
+      />
         
       <DescriptionComponent
           class="description-component"
@@ -27,7 +29,7 @@
 
       <div class="result-bar-container">
         <ResultBar 
-          resultTitle="결과" 
+          resultTitle="전체 게시물" 
           :sortOptions="sortOptions"
           @updateSortBy="updateSortBy"
         />
@@ -50,7 +52,9 @@
 
 <script setup>
 import { ref, reactive, onMounted, watch } from "vue";
+import router from '@/router';
 import { useRouter } from "vue-router";
+
 import { axiosInstance } from "@/plugins/axiosPlugin";
 
 import { useInfiniteScroll } from "@/composables/useInfiniteScroll.js";
@@ -63,7 +67,7 @@ import ResultBar from "@/components/common/ResultBar.vue";
 import TagButtonGroup from "@/components/common/TagButtonGroup.vue";
 import PostList from "@/components/post/PostList.vue";
 
-const router = useRouter();
+// const router = useRouter();
 
 const tagOptions = ref([
   { label: '전체', value: 'ALL' },


### PR DESCRIPTION
**기존 커뮤니티에서 사용하던 검색바 UI를 Search.vue 컴포넌트로 분리하여 재사용이 가능하도록 리팩토링했습니다.**
- 검색바 영역을 별도 컴포넌트(Search.vue)로 분리했습니다.  
- 라우트 이름을 props로 받아 클릭 시 해당 페이지로 이동할 수 있도록 기능을 구현했고,  
- 스타일과 기능 모두 공통 컴포넌트로 관리할 수 있도록 리팩토링했습니다.
